### PR TITLE
Changed "environment" variable to $cron_environment as it conflicted …

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -9,7 +9,7 @@
 #     Defaults to '0'.
 #   hour - The hour the cron job should fire on. Can be any valid cron hour value.
 #     Defaults to '0'.
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
@@ -26,31 +26,31 @@
 #     'mysql backup':
 #       minute      => '1',
 #       hour        => '3',
-#       environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
+#       cron_environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 #       command     => 'mysqldump -u root my_db >/mnt/backups/db/daily/my_db_$(date "+%Y%m%d").sql';
 #   }
 #
 define cron::daily (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
+  $ensure           = 'present',
+  $minute           = 0,
+  $hour             = 0,
+  $cron_environment = [],
+  $user             = 'root',
+  $mode             = '0644',
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => $hour,
-    date        => '*',
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
+    ensure            => $ensure,
+    minute            => $minute,
+    hour              => $hour,
+    date              => '*',
+    month             => '*',
+    weekday           => '*',
+    user              => $user,
+    cron_environment  => $cron_environment,
+    mode              => $mode,
+    command           => $command,
   }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -7,7 +7,7 @@
 #     Defaults to 'present'
 #   minute - The minute the cron job should fire on. Can be any valid cron minute value.
 #     Defaults to '0'.
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file
 #     Defaults to 0644.
@@ -22,30 +22,30 @@
 #   cron::hourly {
 #     'generate puppetdoc':
 #       minute      => '1',
-#       environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
+#       cron_environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 #       command     => 'puppet doc --modulepath /etc/puppet/modules >/var/www/puppet_docs.mkd';
 #   }
 #
 define cron::hourly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
+  $ensure           = 'present',
+  $minute           = 0,
+  $cron_environment = [],
+  $user             = 'root',
+  $mode             = '0644',
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => '*',
-    date        => '*',
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
+    ensure            => $ensure,
+    minute            => $minute,
+    hour              => '*',
+    date              => '*',
+    month             => '*',
+    weekday           => '*',
+    user              => $user,
+    cron_environment  => $cron_environment,
+    mode              => $mode,
+    command           => $command,
   }
 
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -15,7 +15,7 @@
 #     Defaults to '*'.
 #   weekday - The day of the week the cron job should fire on. Can be any valid cron weekday value.
 #     Defaults to '*'.
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file
 #     Defaults to 0644.
@@ -31,21 +31,21 @@
 #   cron::job {
 #     'generate puppetdoc':
 #       minute      => '01',
-#       environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
+#       cron_environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 #       command     => 'puppet doc --modulepath /etc/puppet/modules >/var/www/puppet_docs.mkd';
 #   }
 #
 define cron::job (
   $command,
-  $ensure      = 'present',
-  $minute      = '*',
-  $hour        = '*',
-  $date        = '*',
-  $month       = '*',
-  $weekday     = '*',
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
+  $ensure           = 'present',
+  $minute           = '*',
+  $hour             = '*',
+  $date             = '*',
+  $month            = '*',
+  $weekday          = '*',
+  $cron_environment = [],
+  $user             = 'root',
+  $mode             = '0644',
 ) {
 
   case $ensure {

--- a/manifests/job/multiple.pp
+++ b/manifests/job/multiple.pp
@@ -7,7 +7,7 @@
 #     cron::job and using the same defaults for each parameter.
 #   ensure - The state to ensure this resource exists in. Can be absent, present
 #     Defaults to 'present'
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file
 #     Defaults to 0644.
@@ -38,9 +38,9 @@
 #
 define cron::job::multiple(
   $jobs,
-  $ensure      = 'present',
-  $environment = [],
-  $mode        = '0644',
+  $ensure           = 'present',
+  $cron_environment = [],
+  $mode             = '0644',
 ) {
 
   case $ensure {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -11,7 +11,7 @@
 #     Defaults to '0'.
 #   date - The date the cron job should fire on. Can be any valid cron date value.
 #     Defaults to '1'.
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
@@ -29,32 +29,32 @@
 #       minute      => '1',
 #       hour        => '7',
 #       date        => '28',
-#       environment => [ 'MAILTO="admin@example.com"' ],
+#       cron_environment => [ 'MAILTO="admin@example.com"' ],
 #       command     => 'find /var/log -type f -ctime +30 -exec rm -f {} \;';
 #   }
 #
 define cron::monthly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $date        = 1,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
+  $ensure           = 'present',
+  $minute           = 0,
+  $hour             = 0,
+  $date             = 1,
+  $cron_environment = [],
+  $user             = 'root',
+  $mode             = '0644',
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => $hour,
-    date        => $date,
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
+    ensure            => $ensure,
+    minute            => $minute,
+    hour              => $hour,
+    date              => $date,
+    month             => '*',
+    weekday           => '*',
+    user              => $user,
+    cron_environment  => $cron_environment,
+    mode              => $mode,
+    command           => $command,
   }
 
 }

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -11,7 +11,7 @@
 #     Defaults to '0'.
 #   weekday - The day of the week the cron job should fire on. Can be any valid cron weekday value.
 #     Defaults to '0'.
-#   environment - An array of environment variable settings.
+#   cron_environment - An array of environment variable settings.
 #     Defaults to an empty set ([]).
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
@@ -29,19 +29,19 @@
 #       minute      => '1',
 #       hour        => '4',
 #       weekday     => '7',
-#       environment => [ 'MAILTO="admin@example.com"' ],
+#       cron_environment => [ 'MAILTO="admin@example.com"' ],
 #       command     => 'find /tmp -type f -ctime +7 -exec rm -f {} \;';
 #   }
 #
 define cron::weekly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $weekday     = 0,
-  $user        = 'root',
-  $mode        = '0640',
-  $environment = [],
+  $ensure           = 'present',
+  $minute           = 0,
+  $hour             = 0,
+  $weekday          = 0,
+  $user             = 'root',
+  $mode             = '0640',
+  $cron_environment = [],
 ) {
 
   cron::job { $title:
@@ -52,7 +52,7 @@ define cron::weekly (
     month       => '*',
     weekday     => $weekday,
     user        => $user,
-    environment => $environment,
+    cron_environment => $cron_environment,
     mode        => $mode,
     command     => $command,
   }

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -5,7 +5,7 @@
 ## <%= @name %> Cron Job
 
 # Environment Settings
-<% Array(@environment).join("\n").split(%r{\n}).each do |env_var|
+<% Array(@cron_environment).join("\n").split(%r{\n}).each do |env_var|
      if env_var.match(%r{\S+=\S+}) -%>
 <%= env_var %>
 <%   elsif env_var.match(%r{\S}) -%>

--- a/templates/multiple.erb
+++ b/templates/multiple.erb
@@ -5,7 +5,7 @@
 ## <%= @name %> Cron Job
 
 # Environment Settings
-<% Array(@environment).join("\n").split(%r{\n}).each do |env_var|
+<% Array(@cron_environment).join("\n").split(%r{\n}).each do |env_var|
      if env_var.match(%r{\S+=\S+}) -%>
 <%= env_var %>
 <%   elsif env_var.match(%r{\S}) -%>


### PR DESCRIPTION
Changed "environment" variable to $cron_environment as it conflicted with global puppet environment variable "environment" used by different ENCs and as result crontab environment couldn't set to desired state.