### PR TITLE
Added the possibility to create cron jobs from Hiera

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,24 @@ This would create the file `/etc/cron.d/mysqlbackup` and run the command `mysqld
       environment => [ 'MAILTO=root', 'PATH="/usr/bin:/bin"', ],
     }
 
+Or define it using YAML:
+
+```yaml
+---
+cron::job:
+  'mysqlbackup':
+    command: 'mysqldump -u root mydb'
+    minute: 0
+    hour: 0
+    date: '*'
+    month: '*'
+    weekday: '*'
+    user: root
+    environment:
+      - 'MAILTO=root'
+      - 'PATH="/usr/bin:/bin"'
+```
+
 ### cron::job::multiple
 
 `cron:job::multiple` creates a file in `/etc/cron.d` with multiple cron jobs configured in it.  
@@ -99,7 +117,7 @@ And parameters of the jobs hash are:
 Example:
 
 ```
-cron::job::multiple { 'test':
+cron::job::multiple { 'test_cron_job_multiple':
   jobs => [
     {
       minute      => '55',
@@ -117,6 +135,30 @@ cron::job::multiple { 'test':
   environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 }
 
+```
+
+YAML definition:
+
+```yaml
+---
+cron::job::multiple:
+  'test_cron_job_multiple':
+    jobs:
+      - {
+          minute: 55,
+          hour: 5,
+          date: '*',
+          month: '*',
+          weekday: '*',
+          user: rmueller,
+          command: '/usr/bin/uname',
+        }
+      - {
+          command: '/usr/bin/sleep 1',
+        }
+
+    environment:
+      - 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"'
 ```
 
 That will generate the file `/etc/cron.d/test` with essentially this content:
@@ -150,6 +192,20 @@ This would create the file `/etc/cron.d/mysqlbackup_hourly` and run the command 
       environment => [ 'MAILTO=root', 'PATH="/usr/bin:/bin"', ],
     }
 
+YAML definition:
+
+```yaml
+---
+cron::hourly:
+  'mysqlbackup_hourly':
+    minute: 20
+    user: root
+    command: 'mysqldump -u root mydb'
+    environment:
+      - 'MAILTO=root'
+      - 'PATH="/usr/bin:/bin"'
+```
+
 ### cron::daily
 
 `cron::daily` creates jobs in `/etc/cron.d` that run once per day.
@@ -172,6 +228,19 @@ This would create the file `/etc/cron.d/mysqlbackup_daily` and run the command `
       user    => 'root',
       command => 'mysqldump -u root mydb',
     }
+
+YAML definition:
+
+```yaml
+---
+cron::daily:
+  'mysqlbackup_daily':
+    minute: 40
+    hour: 2
+    user: root
+    command: 'mysqldump -u root mydb'
+```
+
 
 ### cron::weekly
 
@@ -198,6 +267,20 @@ This would create the file `/etc/cron.d/mysqlbackup_weekly` and run the command 
       command => 'mysqldump -u root mydb',
     }
 
+YAML definition:
+
+```yaml
+---
+cron::weekly:
+  'mysqlbackup_weekly':
+    minute: 40
+    hour: 4
+    weekday: 0
+    user: root
+    command: 'mysqldump -u root mydb'
+```
+
+
 ### cron::monthly
 
 `cron::monthly` creates jobs in `/etc/cron.d` that run once per month.
@@ -222,6 +305,20 @@ This would create the file `/etc/cron.d/mysqlbackup_monthly` and run the command
       user    => 'root',
       command => 'mysqldump -u root mydb',
     }
+
+YAML definition:
+
+```yaml
+---
+cron::monthly:
+  'mysqlbackup_monthly':
+    minute: 40
+    hour: 3
+    date: 1
+    user: root
+    command: 'mysqldump -u root mydb'
+```
+
 
 ## Contributors
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,5 +21,36 @@ class cron (
     package_ensure => $package_ensure,
   }
 
+  # Create jobs from hiera
+  $cron_job=hiera_hash('cron::job','')
+  if $cron_job != '' {
+    create_resources('cron::job',$cron_job)
+  }
+  
+  $cron_job_multiple=hiera_hash('cron::job::multiple','')
+  if $cron_job_multiple != '' {
+    create_resources('cron::job::multiple',$cron_job_multiple)
+  }
+
+  $cron_job_hourly=hiera_hash('cron::hourly','')
+  if $cron_job_hourly != '' {
+    create_resources('cron::hourly',$cron_job_hourly)
+  }
+
+  $cron_job_daily=hiera_hash('cron::daily','')
+  if $cron_job_daily != '' {
+    create_resources('cron::daily',$cron_job_daily)
+  }
+
+  $cron_job_weekly=hiera_hash('cron::weekly','')
+  if $cron_job_weekly != '' {
+    create_resources('cron::weekly',$cron_job_weekly)
+  }
+
+  $cron_job_monthly=hiera_hash('cron::monthly','')
+  if $cron_job_monthly != '' {
+    create_resources('cron::monthly',$cron_job_monthly)
+  }
+
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -22,33 +22,33 @@ class cron (
   }
 
   # Create jobs from hiera
-  $cron_job=hiera_hash('cron::job','')
-  if $cron_job != '' {
+  $cron_job=hiera_hash('cron::job', undef)
+  if $cron_job {
     create_resources('cron::job',$cron_job)
   }
   
-  $cron_job_multiple=hiera_hash('cron::job::multiple','')
-  if $cron_job_multiple != '' {
+  $cron_job_multiple=hiera_hash('cron::job::multiple', undef)
+  if $cron_job_multiple {
     create_resources('cron::job::multiple',$cron_job_multiple)
   }
 
-  $cron_job_hourly=hiera_hash('cron::hourly','')
-  if $cron_job_hourly != '' {
+  $cron_job_hourly=hiera_hash('cron::hourly', undef)
+  if $cron_job_hourly {
     create_resources('cron::hourly',$cron_job_hourly)
   }
 
-  $cron_job_daily=hiera_hash('cron::daily','')
-  if $cron_job_daily != '' {
+  $cron_job_daily=hiera_hash('cron::daily', undef)
+  if $cron_job_daily {
     create_resources('cron::daily',$cron_job_daily)
   }
 
-  $cron_job_weekly=hiera_hash('cron::weekly','')
-  if $cron_job_weekly != '' {
+  $cron_job_weekly=hiera_hash('cron::weekly', undef)
+  if $cron_job_weekly {
     create_resources('cron::weekly',$cron_job_weekly)
   }
 
-  $cron_job_monthly=hiera_hash('cron::monthly','')
-  if $cron_job_monthly != '' {
+  $cron_job_monthly=hiera_hash('cron::monthly', undef)
+  if $cron_job_monthly {
     create_resources('cron::monthly',$cron_job_monthly)
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -21,6 +21,7 @@ class cron::install (
     /(RedHat|CentOS|Amazon|OracleLinux)/ => 'cronie',
     'Gentoo'                             => 'sys-process/vixie-cron',
     'Ubuntu'                             => 'cron',
+    'Debian'                             => 'cron',
     default                              => 'cron',
   }
 

--- a/metadata.json
+++ b/metadata.json
@@ -20,6 +20,10 @@
     {
     "operatingsystem": "Ubuntu",
     "operatingsystemrelease": [ "14.04" ]
+    },
+    {
+    "operatingsystem": "Debian",
+    "operatingsystemrelease": [ "8" ]
     }
    ],
   "dependencies": [


### PR DESCRIPTION
Hi,

I'm using a forked version in production using Hiera to create my cron jobs via YAML files. I updated the README.md to include examples from each job.

Finally I'm also using it in Debian, and it works, so I added the Debian operating system in metadata.json and install.pp files.

Best regards!