### PR TITLE
added description parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ It allows specifying the following parameters:
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
+  * `description` - optional - defaults to undef
 
 Example:  
 This would create the file `/etc/cron.d/mysqlbackup` and run the command `mysqldump -u root mydb` as root at 2:40 AM every day:
@@ -83,6 +84,7 @@ This would create the file `/etc/cron.d/mysqlbackup` and run the command `mysqld
       user        => 'root',
       command     => 'mysqldump -u root mydb',
       environment => [ 'MAILTO=root', 'PATH="/usr/bin:/bin"', ],
+      description => 'Mysql backup',
     }
 
 Hiera example:
@@ -101,6 +103,7 @@ cron::job:
     environment:
       - 'MAILTO=root'
       - 'PATH="/usr/bin:/bin"'
+    description: 'Mysql backup'
 ```
 
 ### cron::job::multiple
@@ -115,13 +118,14 @@ It allows specifiying the following parameters:
 
 And parameters of the jobs hash are:
 
-  * `command` - required - the command to execute
-  * `minute`  - optional - defaults to "\*"
-  * `hour`    - optional - defaults to "\*"
-  * `date`    - optional - defaults to "\*"
-  * `month`   - optional - defaults to "\*"
-  * `weekday` - optional - defaults to "\*"
-  * `user`    - optional - defaults to "root"
+  * `command`     - required - the command to execute
+  * `minute`      - optional - defaults to "\*"
+  * `hour`        - optional - defaults to "\*"
+  * `date`        - optional - defaults to "\*"
+  * `month`       - optional - defaults to "\*"
+  * `weekday`     - optional - defaults to "\*"
+  * `user`        - optional - defaults to "root"
+  * `description` - optional - defaults to undef
 
 Example:
 
@@ -136,9 +140,11 @@ cron::job::multiple { 'test_cron_job_multiple':
       weekday     => '*',
       user        => 'rmueller',
       command     => '/usr/bin/uname',
+      description => 'print system information',
     },
     {
       command     => '/usr/bin/sleep 1',
+      description => 'Sleeping',
     },
   ],
   environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
@@ -161,9 +167,11 @@ cron::job::multiple:
           weekday: '*',
           user: rmueller,
           command: '/usr/bin/uname',
+          description: 'print system information',
         }
       - {
           command: '/usr/bin/sleep 1',
+          description: 'Sleeping',
         }
 
     environment:
@@ -190,6 +198,7 @@ It allows specifying the following parameters:
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
+  * `description` - optional - defaults to undef
 
 Example:  
 This would create the file `/etc/cron.d/mysqlbackup_hourly` and run the command `mysqldump -u root mydb` as root on the 20th minute of every hour:
@@ -227,6 +236,7 @@ It allows specifying the following parameters:
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
+  * `description` - optional - defaults to undef
 
 Example:  
 This would create the file `/etc/cron.d/mysqlbackup_daily` and run the command `mysqldump -u root mydb` as root at 2:40 AM every day, like the above generic example:
@@ -264,6 +274,7 @@ It allows specifying the following parameters:
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
+  * `description` - optional - defaults to undef
 
 Example:  
 This would create the file `/etc/cron.d/mysqlbackup_weekly` and run the command `mysqldump -u root mydb` as root at 4:40 AM every Sunday, like the above generic example:
@@ -303,6 +314,7 @@ It allows specifying the following parameters:
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
+  * `description` - optional - defaults to undef
 
 Example:  
 This would create the file `/etc/cron.d/mysqlbackup_monthly` and run the command `mysqldump -u root mydb` as root at 3:40 AM the 1st of every month, like the above generic example:

--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -17,6 +17,9 @@
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
 #     Defaults to 0644.
+#   description - Optional short description, which will be included in the
+#   cron job file.
+#     Defaults to undef.
 #   command - The command to execute.
 #
 # Actions:
@@ -39,6 +42,7 @@ define cron::daily (
   $environment = [],
   $user        = 'root',
   $mode        = '0644',
+  $description = undef,
 ) {
 
   cron::job { $title:
@@ -52,6 +56,7 @@ define cron::daily (
     environment => $environment,
     mode        => $mode,
     command     => $command,
+    description => $description,
   }
 
 }

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -12,7 +12,11 @@
 #     Defaults to an empty set ([]).
 #   mode - The mode to set on the created job file.
 #     Defaults to 0644.
-#   user - The user the cron job should be executed as. Defaults to 'root'.
+#   user - The user the cron job should be executed as.
+#     Defaults to 'root'.
+#   description - Optional short description, which will be included in the
+#   cron job file.
+#     Defaults to undef.
 #   command - The command to execute.
 #
 # Actions:
@@ -33,6 +37,7 @@ define cron::hourly (
   $environment = [],
   $user        = 'root',
   $mode        = '0644',
+  $description = undef,
 ) {
 
   cron::job { $title:
@@ -46,6 +51,7 @@ define cron::hourly (
     environment => $environment,
     mode        => $mode,
     command     => $command,
+    description => $description,
   }
 
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -26,6 +26,9 @@
 #     Defaults to 0644.
 #   user - The user the cron job should be executed as.
 #     Defaults to 'root'.
+#   description - Optional short description, which will be included in the
+#   cron job file.
+#     Defaults to undef.
 #   command - The command to execute.
 #
 # Actions:
@@ -50,6 +53,7 @@ define cron::job (
   $environment = [],
   $user        = 'root',
   $mode        = '0644',
+  $description = undef,
 ) {
 
   case $ensure {

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -20,6 +20,9 @@
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
 #     Defaults to 0644.
+#   description - Optional short description, which will be included in the
+#   cron job file.
+#     Defaults to undef.
 #   command - The command to execute.
 #
 # Actions:
@@ -44,6 +47,7 @@ define cron::monthly (
   $environment = [],
   $user        = 'root',
   $mode        = '0644',
+  $description = undef,
 ) {
 
   cron::job { $title:
@@ -57,6 +61,7 @@ define cron::monthly (
     environment => $environment,
     mode        => $mode,
     command     => $command,
+    description => $description,
   }
 
 }

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -20,6 +20,9 @@
 #     Defaults to 'root'.
 #   mode - The mode to set on the created job file
 #     Defaults to '0640'.
+#   description - Optional short description, which will be included in the
+#   cron job file.
+#     Defaults to undef.
 #   command - The command to execute.
 #
 # Actions:
@@ -44,6 +47,7 @@ define cron::weekly (
   $user        = 'root',
   $mode        = '0640',
   $environment = [],
+  $description = undef,
 ) {
 
   cron::job { $title:
@@ -57,6 +61,7 @@ define cron::weekly (
     environment => $environment,
     mode        => $mode,
     command     => $command,
+    description => $description,
   }
 
 }

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -32,6 +32,7 @@ describe 'cron::job' do
       :environment => [ 'MAILTO="root"', 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
       :user        => 'admin',
       :mode        => '0640',
+      :description => 'Mysql backup',
       :command     => 'mysqldump -u root test_db >some_file',
     }}
     let( :cron_timestamp ) { get_timestamp( params ) }
@@ -48,6 +49,8 @@ describe 'cron::job' do
         /\s+#{params[:user]}\s+/
       ).with_content(
         /\s+#{params[:command]}\n/
+      ).with_content(
+        /\n# #{params[:description]}\n/
       )
     end
   end

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -14,5 +14,8 @@
    end -%>
 
 # Job Definition
+<% if @description -%>
+# <%= @description %>
+<% end -%>
 <%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %>  <%= @command %>
 

--- a/templates/multiple.erb
+++ b/templates/multiple.erb
@@ -35,5 +35,9 @@
   <%- if job['user'].nil? -%>
     <%- job['user'] = 'root' -%>
   <%- end -%>
+<% if job.has_key?('description') -%>
+
+# <%= job['description'] %>
+<% end -%>
 <%= job['minute'] %> <%= job['hour'] %> <%= job['date'] %> <%= job['month'] %> <%= job['weekday'] %>  <%= job['user'] %>  <%= job['command'] %>
 <% end -%>


### PR DESCRIPTION
This adds the option to add a short description to a cron job. If you are generally willing to merge, I can add documentation, spec tests etc.