### PR TITLE
Use package 'virtual/cron' on Gentoo

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,7 +27,7 @@ class cron::install (
       }
     }
     'Gentoo': {
-      $package_name = 'sys-process/vixie-cron'
+      $package_name = 'virtual/cron'
     }
     'Ubuntu': {
       $package_name = 'cron'


### PR DESCRIPTION
Gentoo has several choises for which cron package to use. If you use
some other cron and the module tries to install vixie-cron it resulst
in package conflict.

 Error: Execution of '/usr/bin/emerge sys-process/vixie-cron' returned 1: Calculating dependencies  ... done!
 [ebuild  N     ] sys-process/vixie-cron-4.1-r14  USE="-debug -pam (-selinux)"
 [blocks B      ] sys-process/cronie ("sys-process/cronie" is blocking sys-process/vixie-cron-4.1-r14)
 [blocks B      ] sys-process/vixie-cron ("sys-process/vixie-cron" is blocking sys-process/cronie-1.5.0-r1)

  * Error: The above package list contains packages which cannot be
  * installed at the same time on the same system.

This is can be avoided by using Gentoo virtual cron package instead,
which ensures that a cron package gets installed if it's not already
present.