### PR TITLE
Fix gentoo package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,15 @@ If you want to use Hiera to configure your cronjobs, you must declare the `cron`
 
 You can disable the managment of the cron package by setting the `manage_package` parameter to `false`.
 
+You can also specify a different cron package name via `package_name`.  
+By default we try to select the right one for your distribution.  
+But in some cases (e.g. Gentoo) you might want to overwrite it here.  
+
 This class allows specifiying the following parameter:
 
    * `manage_package` - optional - defaults to "true"
    * `package_ensure` - optional - defaults to "installed"
+   * `package_name`   - optional - defaults to "undef"
 
 
 Examples:  

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,8 @@
 #     'present'.
 #     Default: installed
 #
+#   package_name - Can be set to install a different cron package.
+#     Default: undef
 #
 # Actions:
 #
@@ -26,11 +28,13 @@
 class cron (
   $manage_package = true,
   $package_ensure = 'installed',
+  $package_name   = undef,
 ) {
 
   if $manage_package {
     class { '::cron::install':
       package_ensure => $package_ensure,
+      package_name   => $package_name,
     }
   }
 

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -5,6 +5,10 @@
 # Parameters:
 #   package_ensure - Can be set to a package version, 'latest', 'installed' or
 #   'present'.
+#     Default: installed
+#
+#   package_name - Can be used to install a different cron package.
+#     Default: undef
 #
 # Actions:
 #
@@ -16,33 +20,38 @@
 #
 class cron::install (
   $package_ensure = 'installed',
+  $package_name   = undef,
 ) {
 
-  case $::operatingsystem {
-    /^(RedHat|CentOS|Amazon|OracleLinux)/: {
-      if versioncmp($::operatingsystemmajrelease, '5') <= 0 {
-        $package_name = 'vixie-cron'
-      } else {
-        $package_name = 'cronie'
+  if $package_name {
+    $real_package_name = $package_name
+  } else {
+    case $::operatingsystem {
+      /^(RedHat|CentOS|Amazon|OracleLinux)/: {
+        if versioncmp($::operatingsystemmajrelease, '5') <= 0 {
+          $real_package_name = 'vixie-cron'
+        } else {
+          $real_package_name = 'cronie'
+        }
       }
-    }
-    'Gentoo': {
-      $package_name = 'virtual/cron'
-    }
-    'Ubuntu': {
-      $package_name = 'cron'
-    }
-    'Debian': {
-      $package_name = 'cron'
-    }
-    default: {
-      $package_name = 'cron'
+      'Gentoo': {
+        $real_package_name = 'virtual/cron'
+      }
+      'Ubuntu': {
+        $real_package_name = 'cron'
+      }
+      'Debian': {
+        $real_package_name = 'cron'
+      }
+      default: {
+        $real_package_name = 'cron'
+      }
     }
   }
 
   package { 'cron':
     ensure => $package_ensure,
-    name   => $package_name,
+    name   => $real_package_name,
   }
 
 }

--- a/spec/classes/cron_spec.rb
+++ b/spec/classes/cron_spec.rb
@@ -52,4 +52,21 @@ describe 'cron' do
       )
     }
   end
+
+  context 'package_name => sys-process/cronie' do
+    let :facts do
+      {
+        :operatingsystem           => 'Gentoo',
+      }
+    end
+    let( :params ) {{ :package_name => 'sys-process/cronie', }}
+
+    it { should contain_class( 'cron::install' ) }
+    it { should contain_package( 'cron' ).with(
+      'name'   => 'sys-process/cronie',
+      'ensure' => 'installed'
+      )
+    }
+  end
+
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -50,7 +50,7 @@ describe 'cron::install' do
     end
     it { should contain_class( 'cron::install' ) }
     it { should contain_package( 'cron' ).with(
-      'name' => 'sys-process/vixie-cron'
+      'name' => 'virtual/cron'
       )
     }
   end


### PR DESCRIPTION
As discussed via https://github.com/roman-mueller/rmueller-cron/pull/6: Gentoo should use the `virtual/cron` package by default.
Additionally it should be possible to overwrite the package name.