### PR TITLE
Updated to allow arrays of package names to be supplied

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -49,9 +49,8 @@ class cron::install (
     }
   }
 
-  package { 'cron':
+  package { $real_package_name :
     ensure => $package_ensure,
-    name   => $real_package_name,
   }
 
 }


### PR DESCRIPTION
Updated the install.pp file to use package_name as the resources title which allows strings and arrays of packages to be passed. This solves the issue on RHEL/Centos when both cronie and cronie-anacron packages are desired for cron setup.