### PR TITLE
added check_mk mk-job support

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -36,28 +36,29 @@
 #
 define cron::daily (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  $ensure       = 'present',
+  $minute       = 0,
+  $hour         = 0,
+  $environment  = [],
+  $user         = 'root',
+  $mode         = '0644',
+  $description  = undef,
+  $check_mk_job = false,
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => $hour,
-    date        => '*',
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
-    description => $description,
+    ensure       => $ensure,
+    minute       => $minute,
+    hour         => $hour,
+    date         => '*',
+    month        => '*',
+    weekday      => '*',
+    user         => $user,
+    environment  => $environment,
+    mode         => $mode,
+    command      => $command,
+    description  => $description,
+    check_mk_job => $check_mk_job,
   }
 
 }
-

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -32,27 +32,28 @@
 #
 define cron::hourly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  $ensure       = 'present',
+  $minute       = 0,
+  $environment  = [],
+  $user         = 'root',
+  $mode         = '0644',
+  $description  = undef,
+  $check_mk_job = false,
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => '*',
-    date        => '*',
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
-    description => $description,
+    ensure       => $ensure,
+    minute       => $minute,
+    hour         => '*',
+    date         => '*',
+    month        => '*',
+    weekday      => '*',
+    user         => $user,
+    environment  => $environment,
+    mode         => $mode,
+    command      => $command,
+    description  => $description,
+    check_mk_job => $check_mk_job,
   }
 
 }
-

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -44,16 +44,17 @@
 #
 define cron::job (
   $command,
-  $ensure      = 'present',
-  $minute      = '*',
-  $hour        = '*',
-  $date        = '*',
-  $month       = '*',
-  $weekday     = '*',
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  $ensure       = 'present',
+  $minute       = '*',
+  $hour         = '*',
+  $date         = '*',
+  $month        = '*',
+  $weekday      = '*',
+  $environment  = [],
+  $user         = 'root',
+  $mode         = '0644',
+  $check_mk_job = false,
+  $description  = undef,
 ) {
 
   case $ensure {
@@ -62,10 +63,9 @@ define cron::job (
     default:   { fail("Invalid value '${ensure}' used for ensure") }
   }
 
-  if $command =~ /^mk-job .*$/ {
+  if $check_mk_job == true {
     ensure_resource('file', "/var/lib/check_mk_agent/job/${user}", {
       ensure  => directory,
-      require => Class['check_mk::agent'],
       path    => "/var/lib/check_mk_agent/job/${user}",
       mode    => '0750',
       owner   => $user,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -66,7 +66,6 @@ define cron::job (
   if $check_mk_job == true {
     ensure_resource('file', "/var/lib/check_mk_agent/job/${user}", {
       ensure  => directory,
-      require => Class['check_mk::agent'],
       path    => "/var/lib/check_mk_agent/job/${user}",
       mode    => '0750',
       owner   => $user,

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -62,6 +62,16 @@ define cron::job (
     default:   { fail("Invalid value '${ensure}' used for ensure") }
   }
 
+  if $command =~ /^mk-job .*$/ {
+    file { "/var/lib/check_mk_agent/job/${user}":
+      ensure => directory,
+      path   => "/var/lib/check_mk_agent/job/${user}",
+      owner  => $user,
+      group  => $user,
+      mode   => '0755';
+    }
+  }
+
   file { "job_${title}":
     ensure  => $real_ensure,
     owner   => 'root',
@@ -72,4 +82,3 @@ define cron::job (
   }
 
 }
-

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -63,13 +63,14 @@ define cron::job (
   }
 
   if $command =~ /^mk-job .*$/ {
-    file { "/var/lib/check_mk_agent/job/${user}":
-      ensure => directory,
-      path   => "/var/lib/check_mk_agent/job/${user}",
-      owner  => $user,
-      group  => $user,
-      mode   => '0755';
-    }
+    ensure_resource('file', "/var/lib/check_mk_agent/job/${user}", {
+      ensure  => directory,
+      require => Class['check_mk::agent'],
+      path    => "/var/lib/check_mk_agent/job/${user}",
+      mode    => '0750',
+      owner   => $user,
+      group   => $user,
+    })
   }
 
   file { "job_${title}":

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -66,6 +66,7 @@ define cron::job (
   if $check_mk_job == true {
     ensure_resource('file', "/var/lib/check_mk_agent/job/${user}", {
       ensure  => directory,
+      require => Class['check_mk::agent'],
       path    => "/var/lib/check_mk_agent/job/${user}",
       mode    => '0750',
       owner   => $user,

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -40,29 +40,30 @@
 #
 define cron::monthly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $date        = 1,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  $ensure       = 'present',
+  $minute       = 0,
+  $hour         = 0,
+  $date         = 1,
+  $environment  = [],
+  $user         = 'root',
+  $mode         = '0644',
+  $description  = undef,
+  $check_mk_job = false,
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => $hour,
-    date        => $date,
-    month       => '*',
-    weekday     => '*',
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
-    description => $description,
+    ensure       => $ensure,
+    minute       => $minute,
+    hour         => $hour,
+    date         => $date,
+    month        => '*',
+    weekday      => '*',
+    user         => $user,
+    environment  => $environment,
+    mode         => $mode,
+    command      => $command,
+    description  => $description,
+    check_mk_job => $check_mk_job,
   }
 
 }
-

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -40,29 +40,30 @@
 #
 define cron::weekly (
   $command,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $weekday     = 0,
-  $user        = 'root',
-  $mode        = '0640',
-  $environment = [],
-  $description = undef,
+  $ensure       = 'present',
+  $minute       = 0,
+  $hour         = 0,
+  $weekday      = 0,
+  $user         = 'root',
+  $mode         = '0640',
+  $environment  = [],
+  $description  = undef,
+  $check_mk_job = false,
 ) {
 
   cron::job { $title:
-    ensure      => $ensure,
-    minute      => $minute,
-    hour        => $hour,
-    date        => '*',
-    month       => '*',
-    weekday     => $weekday,
-    user        => $user,
-    environment => $environment,
-    mode        => $mode,
-    command     => $command,
-    description => $description,
+    ensure       => $ensure,
+    minute       => $minute,
+    hour         => $hour,
+    date         => '*',
+    month        => '*',
+    weekday      => $weekday,
+    user         => $user,
+    environment  => $environment,
+    mode         => $mode,
+    command      => $command,
+    description  => $description,
+    check_mk_job => $check_mk_job,
   }
 
 }
-

--- a/metadata.json
+++ b/metadata.json
@@ -50,6 +50,7 @@
     }
   ],
   "dependencies": [
+    {"name":"puppetlabs/stdlib","version_requirement":">= 3.2.1"}
   ]
 }
 

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -17,5 +17,4 @@
 <% if @description -%>
 # <%= @description %>
 <% end -%>
-<%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %>  <%= @command %>
-
+<%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %><% if @check_mk_job == true -%> mk-job <%= @title %><% end -%> <%= @command %>

--- a/templates/multiple.erb
+++ b/templates/multiple.erb
@@ -39,5 +39,5 @@
 
 # <%= job['description'] %>
 <% end -%>
-<%= job['minute'] %> <%= job['hour'] %> <%= job['date'] %> <%= job['month'] %> <%= job['weekday'] %>  <%= job['user'] %>  <%= job['command'] %>
+<%= job['minute'] %> <%= job['hour'] %> <%= job['date'] %> <%= job['month'] %> <%= job['weekday'] %>  <%= job['user'] %><% if job['check_mk_job'] == true -%> mk-job <%= @title %><% end -%> <%= job['command'] %>
 <% end -%>


### PR DESCRIPTION
check_mks mk-job command, which collects execution state and runtime statistics of cron jobs (https://mathias-kettner.de/checkmk_job.html), needs own folder to run non root cron jobs.

This addition checks for cron jobs which starts with "mk-job" wrapper command and creates needed non root folder if needed.
