### PR TITLE
Add support for special time options

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,10 +157,10 @@ cron::job::multiple { 'test_cron_job_multiple':
       command     => '/usr/bin/sleep 1',
       description => 'Sleeping',
     },
-	{
-	  command     => '/usr/bin/sleep 10',
-	  special     => 'reboot',
-	},
+    {
+      command     => '/usr/bin/sleep 10',
+      special     => 'reboot',
+    },
   ],
   environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 }

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ It allows specifying the following parameters:
   * `date`        - optional - defaults to "\*"
   * `month`       - optional - defaults to "\*"
   * `weekday`     - optional - defaults to "\*"
+  * `special`     - optional - defaults to undef
   * `user`        - optional - defaults to "root"
   * `environment` - optional - defaults to ""
   * `mode`        - optional - defaults to "0644"
@@ -133,6 +134,7 @@ And the keys of the jobs hash are:
   * `date`        - optional - defaults to "\*"
   * `month`       - optional - defaults to "\*"
   * `weekday`     - optional - defaults to "\*"
+  * `special`     - optional - defaults to undef
   * `user`        - optional - defaults to "root"
   * `description` - optional - defaults to undef
 
@@ -155,6 +157,10 @@ cron::job::multiple { 'test_cron_job_multiple':
       command     => '/usr/bin/sleep 1',
       description => 'Sleeping',
     },
+	{
+	  command     => '/usr/bin/sleep 10',
+	  special     => 'reboot',
+	},
   ],
   environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 }
@@ -182,6 +188,10 @@ cron::job::multiple:
           command: '/usr/bin/sleep 1',
           description: 'Sleeping',
         }
+      - {
+          command: '/usr/bin/sleep 10',
+          special: 'reboot',
+        }
 
     environment:
       - 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"'
@@ -194,6 +204,7 @@ PATH="/usr/sbin:/usr/bin:/sbin:/bin"
 
 55 5 * * *  rmueller  /usr/bin/uname
 * * * * *  root  /usr/bin/sleep 1
+@reboot  root  /usr/bin/sleep 10
 ```
 
 ### cron::hourly

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -50,6 +50,7 @@ define cron::job (
   $date        = '*',
   $month       = '*',
   $weekday     = '*',
+  $special     = undef,
   $environment = [],
   $user        = 'root',
   $mode        = '0644',

--- a/manifests/job/multiple.pp
+++ b/manifests/job/multiple.pp
@@ -28,13 +28,18 @@
 #     {
 #       command     => '/usr/bin/sleep 1',
 #     },
+#     {
+#       command     => '/usr/bin/sleep 10',
+#       special     => 'reboot',
+#     },
 #   ],
 #   environment => [ 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
 # }
 # 
-# This will generate those two cron jobs in `/etc/cron.d/test`:
+# This will generate those three cron jobs in `/etc/cron.d/test`:
 # 55 5 * * *  rmueller  /usr/bin/uname
 # * * * * *  root  /usr/bin/sleep 1
+# @reboot root /usr/bin/sleep 10
 #
 define cron::job::multiple(
   $jobs,

--- a/templates/job.erb
+++ b/templates/job.erb
@@ -17,5 +17,8 @@
 <% if @description -%>
 # <%= @description %>
 <% end -%>
+<%- if @special.nil? -%>
 <%= @minute %> <%= @hour %> <%= @date %> <%= @month %> <%= @weekday %>  <%= @user %>  <%= @command %>
-
+<%  else -%>
+@<%= @special %>  <%= @user %>  <%= @command %>
+<%  end -%>

--- a/templates/multiple.erb
+++ b/templates/multiple.erb
@@ -39,5 +39,9 @@
 
 # <%= job['description'] %>
 <% end -%>
+<%- if job['special'].nil? -%>
 <%= job['minute'] %> <%= job['hour'] %> <%= job['date'] %> <%= job['month'] %> <%= job['weekday'] %>  <%= job['user'] %>  <%= job['command'] %>
+<%  else -%>
+@<%= job['special'] %>  <%= job['user'] %>  <%= job['command'] %>
+<%  end -%>
 <% end -%>


### PR DESCRIPTION
This pull request adds support for special time options the same way the puppet cron module provides.

https://docs.puppet.com/puppet/latest/types/cron.html#cron-attribute-special

Only difference is that you can not provide the value absent to disable it, you need to set it to undef.

Since I wanted to keep the module mostly sane, I didn't implement a check to see if cron actually supports this flag.
