### PR TITLE
Make the cron::job command attribute optional.

### DIFF
--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -43,7 +43,7 @@
 #   }
 #
 define cron::job (
-  $command,
+  $command     = undef,
   $ensure      = 'present',
   $minute      = '*',
   $hour        = '*',
@@ -58,19 +58,23 @@ define cron::job (
 ) {
 
   case $ensure {
-    'present': { $real_ensure = file }
-    'absent':  { $real_ensure = absent }
-    default:   { fail("Invalid value '${ensure}' used for ensure") }
+    'absent':  {
+      file { "job_${title}":
+        ensure  => 'absent',
+      }
+    }
+    'present': {
+      file { "job_${title}":
+        ensure  => 'file',
+        owner   => 'root',
+        group   => 'root',
+        mode    => $mode,
+        path    => "/etc/cron.d/${title}",
+        content => template('cron/job.erb'),
+      }
+    }
+    default: {
+      fail("Invalid value '${ensure}' used for ensure.")
+    }
   }
-
-  file { "job_${title}":
-    ensure  => $real_ensure,
-    owner   => 'root',
-    group   => 'root',
-    mode    => $mode,
-    path    => "/etc/cron.d/${title}",
-    content => template('cron/job.erb'),
-  }
-
 }
-

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -58,7 +58,6 @@ describe 'cron::job' do
   context 'job with ensure set to absent' do
     let( :params ) {{
       :ensure  => 'absent',
-      :command => 'mysqldump -u root test_db >some_file',
     }}
 
     it do


### PR DESCRIPTION
Also, add type-hinting to cron::job attributes so that incorrect attribute types will trigger a run-time error.