### PR TITLE
Make the command attribute optional in other cron:: manifests.

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -35,7 +35,7 @@
 #   }
 #
 define cron::daily (
-  $command,
+  $command     = undef,
   $ensure      = 'present',
   $minute      = 0,
   $hour        = 0,

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -31,7 +31,7 @@
 #   }
 #
 define cron::hourly (
-  $command,
+  $command     = undef,
   $ensure      = 'present',
   $minute      = 0,
   $environment = [],

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -39,7 +39,7 @@
 #   }
 #
 define cron::monthly (
-  $command,
+  $command     = undef,
   $ensure      = 'present',
   $minute      = 0,
   $hour        = 0,

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -39,7 +39,7 @@
 #   }
 #
 define cron::weekly (
-  $command,
+  $command     = undef,
   $ensure      = 'present',
   $minute      = 0,
   $hour        = 0,


### PR DESCRIPTION
Follow-up to #21 