### PR TITLE
Type hinting

### DIFF
--- a/manifests/daily.pp
+++ b/manifests/daily.pp
@@ -35,14 +35,14 @@
 #   }
 #
 define cron::daily (
-  $command     = undef,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  Optional[String[1]]        $command     = undef,
+  Enum['absent','present']   $ensure      = 'present',
+  Variant[Integer,String[1]] $minute      = 0,
+  Variant[Integer,String[1]] $hour        = 0,
+  Array[String]              $environment = [],
+  String[1]                  $user        = 'root',
+  String[4,4]                $mode        = '0644',
+  Optional[String]           $description = undef,
 ) {
 
   cron::job { $title:

--- a/manifests/hourly.pp
+++ b/manifests/hourly.pp
@@ -31,13 +31,13 @@
 #   }
 #
 define cron::hourly (
-  $command     = undef,
-  $ensure      = 'present',
-  $minute      = 0,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  Optional[String[1]]        $command     = undef,
+  Enum['absent','present']   $ensure      = 'present',
+  Variant[Integer,String[1]] $minute      = 0,
+  Array[String]              $environment = [],
+  String[1]                  $user        = 'root',
+  String[4,4]                $mode        = '0644',
+  Optional[String]           $description = undef,
 ) {
 
   cron::job { $title:

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,16 +34,26 @@
 #   }
 #
 class cron (
-  $manage_package = true,
-  $manage_service = true,
-  $service_ensure = 'running',
-  $service_enable = true,
-  $service_name   = $::cron::params::service_name,
-  $package_ensure = 'installed',
-  $package_name   = $::cron::params::package_name,
+  Boolean        $manage_package = true,
+  Boolean        $manage_service = true,
+  Variant[
+    Boolean,
+    Enum[
+      'running',
+      'stopped',
+    ]
+  ]              $service_ensure = 'running',
+  Variant[
+    Boolean,
+    Enum[
+      'manual',
+      'mask',
+    ]
+  ]              $service_enable = true,
+  String[1]      $service_name   = $::cron::params::service_name,
+  String[1]      $package_ensure = 'installed',
+  String[1]      $package_name   = $::cron::params::package_name,
 ) inherits cron::params {
-
-  validate_bool($manage_package, $manage_service, $service_enable)
 
   include ::cron::install
   include ::cron::service

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -43,18 +43,18 @@
 #   }
 #
 define cron::job (
-  $command     = undef,
-  $ensure      = 'present',
-  $minute      = '*',
-  $hour        = '*',
-  $date        = '*',
-  $month       = '*',
-  $weekday     = '*',
-  $special     = undef,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  Optional[String[1]]        $command     = undef,
+  Enum['absent','present']   $ensure      = 'present',
+  Variant[Integer,String[1]] $minute      = '*',
+  Variant[Integer,String[1]] $hour        = '*',
+  Variant[Integer,String[1]] $date        = '*',
+  Variant[Integer,String[1]] $month       = '*',
+  Variant[Integer,String[1]] $weekday     = '*',
+  Optional[String[1]]        $special     = undef,
+  Array[String]              $environment = [],
+  String[1]                  $user        = 'root',
+  String[4,4]                $mode        = '0644',
+  Optional[String]           $description = undef,
 ) {
 
   case $ensure {
@@ -64,7 +64,7 @@ define cron::job (
         path   => "/etc/cron.d/${title}",
       }
     }
-    'present': {
+    default: {
       file { "job_${title}":
         ensure  => 'file',
         owner   => 'root',
@@ -73,9 +73,6 @@ define cron::job (
         path    => "/etc/cron.d/${title}",
         content => template('cron/job.erb'),
       }
-    }
-    default: {
-      fail("Invalid value '${ensure}' used for ensure.")
     }
   }
 }

--- a/manifests/job.pp
+++ b/manifests/job.pp
@@ -60,7 +60,8 @@ define cron::job (
   case $ensure {
     'absent':  {
       file { "job_${title}":
-        ensure  => 'absent',
+        ensure => 'absent',
+        path   => "/etc/cron.d/${title}",
       }
     }
     'present': {

--- a/manifests/job/multiple.pp
+++ b/manifests/job/multiple.pp
@@ -42,25 +42,38 @@
 # @reboot root /usr/bin/sleep 10
 #
 define cron::job::multiple(
-  $jobs,
-  $ensure      = 'present',
-  $environment = [],
-  $mode        = '0644',
+  Array[Struct[{
+    Optional['command']     => String[1],
+    Optional['minute']      => Variant[Integer,String[1]],
+    Optional['hour']        => Variant[Integer,String[1]],
+    Optional['date']        => Variant[Integer,String[1]],
+    Optional['month']       => Variant[Integer,String[1]],
+    Optional['weekday']     => Variant[Integer,String[1]],
+    Optional['special']     => String[1],
+    Optional['environment'] => Array[String],
+    Optional['user']        => String[1],
+    Optional['description'] => String,
+  }]]                      $jobs,
+  Enum['absent','present'] $ensure      = 'present',
+  Array[String]            $environment = [],
+  String[4,4]              $mode        = '0644',
 ) {
-
   case $ensure {
-    'present': { $real_ensure = file }
-    'absent':  { $real_ensure = absent }
-    default:   { fail("Invalid value '${ensure}' used for ensure") }
+    'absent': {
+      file { "job_${title}":
+        ensure => absent,
+        path   => "/etc/cron.d/${title}",
+      }
+    }
+    default:  {
+      file { "job_${title}":
+        ensure  => $ensure,
+        owner   => 'root',
+        group   => 'root',
+        mode    => $mode,
+        path    => "/etc/cron.d/${title}",
+        content => template('cron/multiple.erb'),
+      }
+    }
   }
-
-  file { "job_${title}":
-    ensure  => $real_ensure,
-    owner   => 'root',
-    group   => 'root',
-    mode    => $mode,
-    path    => "/etc/cron.d/${title}",
-    content => template('cron/multiple.erb'),
-  }
-
 }

--- a/manifests/monthly.pp
+++ b/manifests/monthly.pp
@@ -39,15 +39,15 @@
 #   }
 #
 define cron::monthly (
-  $command     = undef,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $date        = 1,
-  $environment = [],
-  $user        = 'root',
-  $mode        = '0644',
-  $description = undef,
+  Optional[String[1]]        $command     = undef,
+  Enum['absent','present']   $ensure      = 'present',
+  Variant[Integer,String[1]] $minute      = 0,
+  Variant[Integer,String[1]] $hour        = 0,
+  Variant[Integer,String[1]] $date        = 1,
+  Array[String]              $environment = [],
+  String[1]                  $user        = 'root',
+  String[4,4]                $mode        = '0644',
+  Optional[String]           $description = undef,
 ) {
 
   cron::job { $title:

--- a/manifests/weekly.pp
+++ b/manifests/weekly.pp
@@ -39,15 +39,15 @@
 #   }
 #
 define cron::weekly (
-  $command     = undef,
-  $ensure      = 'present',
-  $minute      = 0,
-  $hour        = 0,
-  $weekday     = 0,
-  $user        = 'root',
-  $mode        = '0640',
-  $environment = [],
-  $description = undef,
+  Optional[String[1]]        $command     = undef,
+  Enum['absent','present']   $ensure      = 'present',
+  Variant[Integer,String[1]] $minute      = 0,
+  Variant[Integer,String[1]] $hour        = 0,
+  Variant[Integer,String[1]] $weekday     = 0,
+  String[1]                  $user        = 'root',
+  String[4,4]                $mode        = '0644',
+  Array[String]              $environment = [],
+  Optional[String]           $description = undef,
 ) {
 
   cron::job { $title:

--- a/spec/defines/job_spec.rb
+++ b/spec/defines/job_spec.rb
@@ -31,7 +31,7 @@ describe 'cron::job' do
       :weekday     => '*',
       :environment => [ 'MAILTO="root"', 'PATH="/usr/sbin:/usr/bin:/sbin:/bin"' ],
       :user        => 'admin',
-      :mode        => '0640',
+      :mode        => '0644',
       :description => 'Mysql backup',
       :command     => 'mysqldump -u root test_db >some_file',
     }}

--- a/spec/defines/multiple_spec.rb
+++ b/spec/defines/multiple_spec.rb
@@ -14,7 +14,6 @@ describe 'cron::job::multiple' do
           'month'      => '7',
           'weekday'    => '*',
           'user'       => 'admin',
-          'mode'       => '0640',
           'command'    => 'mysqldump -u root test_db >some_file',
         },
         {

--- a/spec/defines/weekly_spec.rb
+++ b/spec/defines/weekly_spec.rb
@@ -18,7 +18,7 @@ describe 'cron::weekly' do
       'weekday'     => params[:weekday],
       'user'        => params[:user] || 'root',
       'environment' => params[:environment] || [],
-      'mode'        => params[:mode] || '0640',
+      'mode'        => params[:mode] || '0644',
       'command'     => params[:command]
     )
   end


### PR DESCRIPTION
Follow-up to #21 and  #22 

Add type-hinting to manifests.  This is now the recommended way to do simple parameter validation, as noted in [stdlib](https://github.com/puppetlabs/puppetlabs-stdlib#validate_legacy).